### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <mybatis-plus.version>3.4.2</mybatis-plus.version>
     <ognl.version>3.1.19</ognl.version>
     <!--plugins-->
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
     <maven-javadoc-plugin>3.2.0</maven-javadoc-plugin>
     <maven-source-plugin>3.2.1</maven-source-plugin>
     <maven-compiler-plugin>3.8.0</maven-compiler-plugin>


### PR DESCRIPTION
jacoco-maven-plugin 0.8.8 中 plexus-utils 组件存在漏洞，jacoco-maven-plugin 0.8.9 中 plexus-utils 组件升级到最小修复版本 参考 https://www.oscs1024.com/hd/MPS-2022-11786