### PR TITLE
refactor(Lazy): Refactor Lazy class to improve initialization

### DIFF
--- a/crane4j-core/src/test/java/cn/crane4j/core/util/LazyTest.java
+++ b/crane4j-core/src/test/java/cn/crane4j/core/util/LazyTest.java
@@ -13,15 +13,30 @@ public class LazyTest {
     @Test
     public void get() {
         Lazy<Object> lazy = new Lazy<>(Object::new);
+        Assert.assertFalse(lazy.isInitialized());
         Object object = lazy.get();
         Assert.assertSame(object, lazy.get());
+        Assert.assertTrue(lazy.isInitialized());
+    }
+
+    @Test
+    public void initAsNull() {
+        Lazy<Object> lazy = new Lazy<>(() -> null);
+        Assert.assertFalse(lazy.isInitialized());
+        Object object = lazy.get();
+        Assert.assertNull(object);
+        Assert.assertTrue(lazy.isInitialized());
+        Assert.assertNull(lazy.get());
+        Assert.assertTrue(lazy.isInitialized());
     }
 
     @Test
     public void refresh() {
         Lazy<Object> lazy = new Lazy<>(Object::new);
         Object object = lazy.get();
+        Assert.assertTrue(lazy.isInitialized());
         lazy.refresh();
+        Assert.assertFalse(lazy.isInitialized());
         Assert.assertNotSame(object, lazy.get());
     }
 }


### PR DESCRIPTION
This PR updates the Lazy class to improve initialization handling and add an isInitialized() method.

The previous version of the Lazy class used null to represent the uninitialized state of the value field. However, this made it difficult to handle the case where the supplier.get() method returns null, which should also be considered as initialized.

To address this issue, we updated the Lazy class to use an UNINITIALIZED_VALUE object instead of null. This allowed us to distinguish between the uninitialized state and the state where supplier.get() returns null.

We also added an isInitialized() method to the Lazy class to check if a value for a given instance has been already initialized.

Feel free to close this PR if it doesn't meet the intended purpose or if there are any issues with the changes.