### PR TITLE
fix(AutoOperate): adding '@AutoOperate' to a method of the same name in a different class will cause padding fields to be messed up (Gitee #I82EAC)

### DIFF
--- a/crane4j-core/src/main/java/cn/crane4j/core/support/aop/MethodArgumentAutoOperateSupport.java
+++ b/crane4j-core/src/main/java/cn/crane4j/core/support/aop/MethodArgumentAutoOperateSupport.java
@@ -48,7 +48,7 @@ public class MethodArgumentAutoOperateSupport {
 
     protected static final AutoOperateAnnotatedElement[] EMPTY_ELEMENTS = new AutoOperateAnnotatedElement[0];
     protected final AutoOperateAnnotatedElementResolver elementResolver;
-    protected final Map<String, AutoOperateAnnotatedElement[]> methodParameterCaches = CollectionUtils.newWeakConcurrentMap();
+    protected final Map<Method, AutoOperateAnnotatedElement[]> methodParameterCaches = CollectionUtils.newWeakConcurrentMap();
     protected final ParameterNameFinder parameterNameFinder;
     protected final AnnotationFinder annotationFinder;
     protected final MethodBaseExpressionExecuteDelegate expressionExecuteDelegate;
@@ -85,8 +85,9 @@ public class MethodArgumentAutoOperateSupport {
         }
         // cache resolved parameters
         ArgAutoOperate methodLevelAnnotation = annotationFinder.findAnnotation(method, ArgAutoOperate.class);
+        // fix https://gitee.com/opengoofy/crane4j/issues/I82EAC
         AutoOperateAnnotatedElement[] elements = CollectionUtils.computeIfAbsent(
-            methodParameterCaches, method.getName(), name -> resolveParameters(methodLevelAnnotation, method)
+            methodParameterCaches, method, name -> resolveParameters(methodLevelAnnotation, method)
         );
         if (elements == EMPTY_ELEMENTS) {
             return;

--- a/crane4j-core/src/main/java/cn/crane4j/core/support/aop/MethodResultAutoOperateSupport.java
+++ b/crane4j-core/src/main/java/cn/crane4j/core/support/aop/MethodResultAutoOperateSupport.java
@@ -29,7 +29,7 @@ import java.util.Objects;
 @Slf4j
 public class MethodResultAutoOperateSupport {
 
-    protected final Map<String, AutoOperateAnnotatedElement> methodCaches = CollectionUtils.newWeakConcurrentMap();
+    protected final Map<Method, AutoOperateAnnotatedElement> methodCaches = CollectionUtils.newWeakConcurrentMap();
     protected final AutoOperateAnnotatedElementResolver elementResolver;
     protected final MethodBaseExpressionExecuteDelegate expressionExecuteDelegate;
 
@@ -61,7 +61,10 @@ public class MethodResultAutoOperateSupport {
         }
         // get and build method cache
         log.debug("process result for [{}]", method);
-        AutoOperateAnnotatedElement element = CollectionUtils.computeIfAbsent(methodCaches, method.getName(), m -> elementResolver.resolve(method, annotation));
+        // fix https://gitee.com/opengoofy/crane4j/issues/I82EAC
+        AutoOperateAnnotatedElement element = CollectionUtils.computeIfAbsent(
+            methodCaches, method, m -> elementResolver.resolve(method, annotation)
+        );
         // whether to apply the operation?
         String condition = element.getAnnotation().condition();
         if (support(method, result, args, condition)) {

--- a/crane4j-extension/crane4j-extension-spring/src/main/java/cn/crane4j/extension/spring/aop/MethodArgumentAutoOperateAdvisor.java
+++ b/crane4j-extension/crane4j-extension-spring/src/main/java/cn/crane4j/extension/spring/aop/MethodArgumentAutoOperateAdvisor.java
@@ -64,7 +64,7 @@ public class MethodArgumentAutoOperateAdvisor
     public Object invoke(MethodInvocation methodInvocation) throws Throwable {
         Method method = methodInvocation.getMethod();
         try {
-            super.beforeMethodInvoke(method, methodInvocation.getArguments());
+            beforeMethodInvoke(method, methodInvocation.getArguments());
         } catch (Exception ex) {
             log.error("cannot auto operate input arguments for method [{}]", method);
             ex.printStackTrace();

--- a/crane4j-extension/crane4j-extension-spring/src/main/java/cn/crane4j/extension/spring/aop/MethodResultAutoOperateAdvisor.java
+++ b/crane4j-extension/crane4j-extension-spring/src/main/java/cn/crane4j/extension/spring/aop/MethodResultAutoOperateAdvisor.java
@@ -54,7 +54,7 @@ public class MethodResultAutoOperateAdvisor
         AutoOperate annotation = AnnotatedElementUtils.findMergedAnnotation(method, AutoOperate.class);
         Object result = methodInvocation.proceed();
         try {
-            super.afterMethodInvoke(annotation, method, result, methodInvocation.getArguments());
+            afterMethodInvoke(annotation, method, result, methodInvocation.getArguments());
         } catch (Exception ex) {
             log.error("cannot auto operate result for method [{}]", method);
             ex.printStackTrace();


### PR DESCRIPTION
[adding '@AutoOperate' to a method of the same name in a different class will cause padding fields to be messed up](https://gitee.com/opengoofy/crane4j/issues/I82EAC)