### PR TITLE
refactor(AsyncBeanOperationExecutor): let AsyncBeanOperationExecutor inherit DisorderedBeanOperationExecutor to avoid repeated access to the same data source in asynchronous populations (Giee #I82EBG)

### DIFF
--- a/crane4j-core/src/main/java/cn/crane4j/core/executor/AsyncBeanOperationExecutor.java
+++ b/crane4j-core/src/main/java/cn/crane4j/core/executor/AsyncBeanOperationExecutor.java
@@ -3,25 +3,26 @@ package cn.crane4j.core.executor;
 import cn.crane4j.core.container.Container;
 import cn.crane4j.core.container.ContainerManager;
 import cn.crane4j.core.exception.OperationExecuteException;
+import cn.crane4j.core.executor.handler.AssembleOperationHandler;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.stream.Collectors;
 
 /**
  * <p>The asynchronous implementation of {@link BeanOperationExecutor}.<br />
  * It will group the operations to be executed according to the data source container,
  * then submit them to the executor in turn, and finally complete them asynchronously.
  *
- * <p>It is not possible to ensure that the operations are executed in order,
- * but only to submit tasks to the thread pool in the order of operations.
- *
  * @author huangchengxing
  */
 @Slf4j
-public class AsyncBeanOperationExecutor extends AbstractBeanOperationExecutor {
+public class AsyncBeanOperationExecutor extends DisorderedBeanOperationExecutor {
 
     /**
      * thread pool used to perform operations.
@@ -76,5 +77,23 @@ public class AsyncBeanOperationExecutor extends AbstractBeanOperationExecutor {
     private void doExecuteOperations(AssembleExecution execution) {
         Container<?> container = execution.getContainer();
         tryExecute(() -> execution.getHandler().process(container, Collections.singleton(execution)));
+    }
+
+    /**
+     * <p>Execute the assembly operation.
+     *
+     * @param executionGroups grouped assembly operations
+     */
+    @Override
+    protected void doExecuteOperations(Map<Container<?>, Map<AssembleOperationHandler, List<AssembleExecution>>> executionGroups) {
+        List<Runnable> tasks = new ArrayList<>(executionGroups.size());
+        executionGroups.forEach((c, he) ->
+            he.forEach((h, es) -> tasks.add(() -> h.process(c, es))));
+        tasks.stream()
+            .map(t -> CompletableFuture.runAsync(t, executorService))
+            .collect(Collectors.collectingAndThen(
+                Collectors.toList(), ts -> CompletableFuture.allOf(ts.toArray(new CompletableFuture[0]))
+            ))
+            .join();
     }
 }


### PR DESCRIPTION
…