### PR TITLE
Fix flaky test in ObjectUtilsTest

### DIFF
--- a/crane4j-core/src/test/java/cn/crane4j/core/util/ObjectUtilsTest.java
+++ b/crane4j-core/src/test/java/cn/crane4j/core/util/ObjectUtilsTest.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -51,8 +52,9 @@ public class ObjectUtilsTest {
         Assert.assertNull(ObjectUtils.get(Arrays.asList(null, null, 3), -1));
         // if target is map
         Assert.assertEquals((Integer)3, ObjectUtils.get(
-            Stream.of(1, 2, 3).collect(Collectors.toMap(Function.identity(), Function.identity())), 2
-        ));
+            Stream.of(1, 2, 3)
+            .collect(Collectors.toMap(Function.identity(), Function.identity(), (existing, replacement) -> existing, LinkedHashMap::new)), 2
+    ));
     }
 
     @Test


### PR DESCRIPTION
Change Assert condition to use LinkedHashMap instead of HashMap to preserve the order of elements in the flaky test.

**Flaky test**

```
cn.crane4j.core.util.ObjectUtilsTest#get
```

https://github.com/opengoofy/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/test/java/cn/crane4j/core/util/ObjectUtilsTest.java#L40

### Problem

Test ```get``` in ```ObjectUtilsTest``` is detected as flaky with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. The test failed with the following error:

```
Running cn.crane4j.core.util.ObjectUtilsTest
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.01 sec <<< FAILURE!
get(cn.crane4j.core.util.ObjectUtilsTest)  Time elapsed: 0.003 sec  <<< FAILURE!
java.lang.AssertionError: expected:<3> but was:<2>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at cn.crane4j.core.util.ObjectUtilsTest.get(ObjectUtilsTest.java:53)
```

### Root cause

There are multiple assertions tested in this test class on ```ObjectUtils.get()``` functionality. In one assertion, a HashMap is created from stream and passed to ```ObjectUtils.get()``` along with the index ```2```. The map contains elements ```1->1 2->2 and 3->3```. The expectation is that value 3 will be returned because there is 3 at index 2 (0-indexed). The ```ObjectUtils.get()``` function returns the element at the requested index. But, a HashMap may not necessarily maintain the order of elements as they are inserted. Therefore, when tested with NonDex tool which shuffles the object elements to test for flakiness, this particular test is found flaky. Since the order of elements is not guaranteed, we cannot expect the value ```3``` to be returned always.

Assertion is made here:

https://github.com/opengoofy/crane4j/blob/b65f7324544381646119be48393f0aa2b3417f2e/crane4j-core/src/test/java/cn/crane4j/core/util/ObjectUtilsTest.java#L53-L55

### Fix

I updated the test to create a LinkedHashMap instead of HashMap to keep the order deterministic.

**This fix will not affect the code since the change is only made in tests.**

### How this has been tested?

**Java:** openjdk version "11.0.20.1"
**Maven:** Apache Maven 3.6.3

1) **Module build** - Successful
Command used - 
```
mvn install -pl crane4j-core -am -DskipTests 
```

2) **Regular test**  - Successful
Command used - 
```
mvn -pl crane4j-core test -Dtest=cn.crane4j.core.util.ObjectUtilsTest#get
```

3) **NonDex test**  - Failed
Command used - 
```
mvn -pl crane4j-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRuns=10 -Dtest=cn.crane4j.core.util.ObjectUtilsTest#get
```

NonDex tests passed after the fix.